### PR TITLE
ci: pin action hashes and escape variables with minimum permission

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,8 @@ name: Linting validation using flake8 & prettier
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -11,19 +12,24 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ["3.10"]
-        node-version: [19.x]
-    
+        python-version:
+          - "3.10"
+        node-version:
+          - 19.x
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Lint with flake8 & Prettier
-      run: |
-        bash scripts/run_lint.sh
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Lint with flake8 & Prettier
+        run: |
+          bash scripts/run_lint.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,8 @@ name: Run all the unit tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -12,17 +13,20 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
-    
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U -r requirements.txt
-    - name: Test with pytest
-      run: |
-        pytest -vv
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U -r requirements.txt
+      - name: Test with pytest
+        run: |
+          pytest -vv


### PR DESCRIPTION
### Summary

This PR uses the wonderful [`zizmor`](https://github.com/zizmorcore/zizmor) tool to audit our own workflows and [`pinact`](https://github.com/suzuki-shunsuke/pinact) for pinned versioning 👾 

### Category

* [x] Others

### Reviewers

A similar audit can be performed with the `zizmor` tool:

```sh
$ zizmor .
...
No findings to report. Good job! (2 suppressed)
```

> The suppressed findings are expected permission blocks at the top-level of a workflow, but we set this for each job.

## Requirements

* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
