### PR TITLE
feat: icon field

### DIFF
--- a/schemas/manifest.schema.1.0.0.json
+++ b/schemas/manifest.schema.1.0.0.json
@@ -158,6 +158,10 @@
           "type": "string",
           "minLength": 175,
           "maxLength": 4000
+        },
+        "icon": {
+          "type": "string",
+          "description": "A string containing a path to the icon image file for the app."
         }
       }
     },

--- a/schemas/manifest.schema.1.0.0.json
+++ b/schemas/manifest.schema.1.0.0.json
@@ -44,6 +44,10 @@
     },
     "external_auth_providers": {
       "$ref": "#/definitions/app-manifests.v1.hermes.third_party_auth.providers"
+    },
+    "icon": {
+      "type": "string",
+      "description": "A string containing a path to the icon image file for the app."
     }
   },
   "definitions": {
@@ -158,10 +162,6 @@
           "type": "string",
           "minLength": 175,
           "maxLength": 4000
-        },
-        "icon": {
-          "type": "string",
-          "description": "A string containing a path to the icon image file for the app."
         }
       }
     },

--- a/schemas/manifest.schema.2.0.0.json
+++ b/schemas/manifest.schema.2.0.0.json
@@ -162,6 +162,10 @@
           "minLength": 175,
           "maxLength": 4000,
           "description": "A string with a longer version of the description of the app. Maximum length is 4000 characters."
+        },
+        "icon": {
+          "type": "string",
+          "description": "A string containing a path to the icon image file for the app."
         }
       },
       "description": "A group of settings that describe parts of an app's appearance within Slack. If you're distributing the app via the App Directory, read our listing guidelines to pick the best values for these settings",

--- a/schemas/manifest.schema.2.0.0.json
+++ b/schemas/manifest.schema.2.0.0.json
@@ -42,6 +42,10 @@
     },
     "external_auth_providers": {
       "$ref": "#/definitions/app-manifests.v2.hermes.third_party_auth.providers"
+    },
+    "icon": {
+      "type": "string",
+      "description": "A string containing a path to the icon image file for the app."
     }
   },
   "description": "Describes core app information and functionality.",
@@ -162,10 +166,6 @@
           "minLength": 175,
           "maxLength": 4000,
           "description": "A string with a longer version of the description of the app. Maximum length is 4000 characters."
-        },
-        "icon": {
-          "type": "string",
-          "description": "A string containing a path to the icon image file for the app."
         }
       },
       "description": "A group of settings that describe parts of an app's appearance within Slack. If you're distributing the app via the App Directory, read our listing guidelines to pick the best values for these settings",


### PR DESCRIPTION
## Summary
Add icon field to both `v1` and `v2` manifest schemas to support `apps.icon.set` functionality (see https://github.com/slackapi/slack-cli/pull/469/). The field is an optional string containing a path to the app's icon image file.                                                                                                                       
### Testing                                                                                           
1. Run ./scripts/install_all_and_run_tests.sh — all 6 tests pass                                  
2. Verify the icon field appears in display_information.properties in both schemas/manifest.schema.1.0.0.json and schemas/manifest.schema.2.0.0.json                         
3. Confirm the field is optional (not added to required array) and accepts any string value

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `manifest.schema.json` edit
* [ ] `/schema` and/or its core components
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
