### PR TITLE
feat: add optional scopes to oauth_config schema

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -56,6 +56,13 @@ This project contains an [`.editorconfig`](../.editorconfig) file. It is used by
 
 ## Testing
 
+Ensure the virtual environment is activated and dependencies are installed before running scripts:
+
+```bash
+source .venv/bin/activate
+pip install -U -e .
+```
+
 ### Run All the Unit Tests
 
 If you make some changes to this SDK, please write corresponding unit tests as much as possible. You can easily run all the tests by running the following script.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,10 @@ Public JSON schemas defining Slack's `manifest.json` file structure. Used by IDE
 ## Commands
 
 ```bash
+# Create and activate a virtual environment (first time only)
+python -m venv .venv
+source .venv/bin/activate
+
 # Install dependencies (first time or after changes)
 pip install -U -e .
 

--- a/schemas/manifest.schema.1.0.0.json
+++ b/schemas/manifest.schema.1.0.0.json
@@ -479,6 +479,22 @@
             "maxLength": 50
           },
           "maxItems": 255
+        },
+        "user_optional": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 50
+          },
+          "maxItems": 255
+        },
+        "bot_optional": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 50
+          },
+          "maxItems": 255
         }
       }
     },

--- a/schemas/manifest.schema.2.0.0.json
+++ b/schemas/manifest.schema.2.0.0.json
@@ -503,6 +503,24 @@
             "maxLength": 50
           },
           "description": "An array of strings containing bot scopes to request upon app installation. A maximum of 255 scopes can included in this array."
+        },
+        "user_optional": {
+          "type": "array",
+          "maxItems": 255,
+          "items": {
+            "type": "string",
+            "maxLength": 50
+          },
+          "description": "An array of strings containing optional user scopes to request upon app installation. A maximum of 255 scopes can included in this array."
+        },
+        "bot_optional": {
+          "type": "array",
+          "maxItems": 255,
+          "items": {
+            "type": "string",
+            "maxLength": 50
+          },
+          "description": "An array of strings containing optional bot scopes to request upon app installation. A maximum of 255 scopes can included in this array."
         }
       },
       "description": "A subgroup of settings that describe permission scopes configuration.",


### PR DESCRIPTION
## Summary

This pull request adds `user_optional` and `bot_optional` scope arrays to the `oauth_config.scopes` schema definition in both v1 and v2 manifest schemas. 

Also updates development documentation to recommend using a `.venv` virtual environment.

### Testing

- Verify the new `user_optional` and `bot_optional` properties appear under `oauth_config.scopes` in both `schemas/manifest.schema.1.0.0.json` and `schemas/manifest.schema.2.0.0.json`
- Confirm the new properties follow the same constraints as existing `user` and `bot` (string items, maxLength 50, maxItems 255)

### Category

* [ ] `manifest.schema.json` edit
* [x] `/schema` and/or its core components
* [x] Others

## Requirements

* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.