### PR TITLE
feat: add settings.is_mcp_enabled and oauth_config.pkce_enabled properties

### DIFF
--- a/schemas/manifest.schema.1.0.0.json
+++ b/schemas/manifest.schema.1.0.0.json
@@ -511,6 +511,9 @@
         },
         "token_management_enabled": {
           "type": "boolean"
+        },
+        "pkce_enabled": {
+          "type": "boolean"
         }
       }
     },

--- a/schemas/manifest.schema.1.0.0.json
+++ b/schemas/manifest.schema.1.0.0.json
@@ -650,6 +650,9 @@
         },
         "function_runtime": {
           "type": "string"
+        },
+        "is_mcp_enabled": {
+          "type": "boolean"
         }
       }
     },

--- a/schemas/manifest.schema.2.0.0.json
+++ b/schemas/manifest.schema.2.0.0.json
@@ -537,6 +537,9 @@
         },
         "token_management_enabled": {
           "type": "boolean"
+        },
+        "pkce_enabled": {
+          "type": "boolean"
         }
       },
       "description": "A group of settings describing OAuth configuration for the app.",
@@ -688,6 +691,9 @@
         },
         "function_runtime": {
           "type": "string"
+        },
+        "is_mcp_enabled": {
+          "type": "boolean"
         }
       },
       "description": "A group of settings corresponding to the Settings section of the app config pages.",


### PR DESCRIPTION
## Summary

Include `pkce_enabled` & `is_mcp_enabled` manifest properties which were recently added to Slack app manifests available on https://api.slack.com/apps

### Testing

` install_all_and_run_tests.sh` run and all 6 tests passed

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `manifest.schema.json` edit
* [x] `/schema` and/or its core components
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
