### PR TITLE
feat: add mcp_servers property and oauth_config PKCE options

### DIFF
--- a/schemas/manifest.schema.1.0.0.json
+++ b/schemas/manifest.schema.1.0.0.json
@@ -1118,8 +1118,9 @@
       }
     },
     "app-manifests.v1.mcp_servers": {
-      "description": "Declares the MCP servers used by the app.",
+      "description": "Declares the MCP servers used by the app. Maximum of 20 servers.",
       "type": "object",
+      "maxProperties": 20,
       "patternProperties": {
         ".*": {
           "type": "object",
@@ -1129,21 +1130,27 @@
             "url": {
               "type": "string",
               "pattern": "^https:\\/\\/",
-              "description": "The URL of the MCP server"
+              "maxLength": 500,
+              "description": "A string containing the URL of the MCP server. Maximum length is 500 characters."
             },
             "auth_provider_key": {
               "type": "string",
-              "description": "The key of the auth provider to use for authentication"
+              "maxLength": 255,
+              "description": "A string referencing the key of an external auth provider to use for authentication. Maximum length is 255 characters."
             },
             "auth_type": {
               "type": "string",
               "enum": [
+                "dynamic_client_registration",
                 "no_auth",
-                "slack_identity_auth",
                 "manual_auth",
-                "dynamic_client_registration"
+                "slack_identity_auth"
               ],
-              "description": "The authentication type for this MCP server"
+              "description": "A string specifying the authentication type. Possible values are dynamic_client_registration, no_auth, manual_auth, or slack_identity_auth."
+            },
+            "headers": {
+              "type": "object",
+              "description": "An object of HTTP headers to send with requests to the MCP server."
             }
           }
         }

--- a/schemas/manifest.schema.1.0.0.json
+++ b/schemas/manifest.schema.1.0.0.json
@@ -44,6 +44,9 @@
     },
     "external_auth_providers": {
       "$ref": "#/definitions/app-manifests.v1.hermes.third_party_auth.providers"
+    },
+    "mcp_servers": {
+      "$ref": "#/definitions/app-manifests.v1.mcp_servers"
     }
   },
   "definitions": {
@@ -1078,6 +1081,20 @@
                           "type": "object"
                         }
                       }
+                    },
+                    "use_pkce": {
+                      "type": "boolean",
+                      "description": "Set to true if your server requires PKCE."
+                    },
+                    "token_url_config": {
+                      "type": "object",
+                      "properties": {
+                        "use_basic_auth_scheme": {
+                          "type": "boolean",
+                          "description": "Set to true if your token endpoint expects client_secret_basic; false for client_secret_post."
+                        }
+                      },
+                      "additionalProperties": false
                     }
                   }
                 }
@@ -1097,6 +1114,38 @@
       "properties": {
         "oauth2": {
           "$ref": "#/definitions/app-manifests.v1.hermes.third_party_auth.providers.oauth2"
+        }
+      }
+    },
+    "app-manifests.v1.mcp_servers": {
+      "description": "Declares the MCP servers used by the app.",
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "required": ["url"],
+          "additionalProperties": false,
+          "properties": {
+            "url": {
+              "type": "string",
+              "pattern": "^https:\\/\\/",
+              "description": "The URL of the MCP server"
+            },
+            "auth_provider_key": {
+              "type": "string",
+              "description": "The key of the auth provider to use for authentication"
+            },
+            "auth_type": {
+              "type": "string",
+              "enum": [
+                "no_auth",
+                "slack_identity_auth",
+                "manual_auth",
+                "dynamic_client_registration"
+              ],
+              "description": "The authentication type for this MCP server"
+            }
+          }
         }
       }
     }

--- a/schemas/manifest.schema.1.0.0.json
+++ b/schemas/manifest.schema.1.0.0.json
@@ -1084,10 +1084,11 @@
                     },
                     "use_pkce": {
                       "type": "boolean",
-                      "description": "Set to true if your server requires PKCE."
+                      "description": "Boolean flag indicating if this provider uses PKCE."
                     },
                     "token_url_config": {
                       "type": "object",
+                      "description": "An object with one boolean value, use_basic_auth_scheme.",
                       "properties": {
                         "use_basic_auth_scheme": {
                           "type": "boolean",

--- a/schemas/manifest.schema.1.0.0.json
+++ b/schemas/manifest.schema.1.0.0.json
@@ -1125,7 +1125,7 @@
       "patternProperties": {
         ".*": {
           "type": "object",
-          "required": ["url"],
+          "required": ["url", "auth_type"],
           "additionalProperties": false,
           "properties": {
             "url": {
@@ -1133,6 +1133,16 @@
               "pattern": "^https:\\/\\/",
               "maxLength": 500,
               "description": "A string containing the URL of the MCP server. Maximum length is 500 characters."
+            },
+            "headers": {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^.+$": {
+                  "type": "string"
+                }
+              },
+              "description": "An object of HTTP headers to send with requests to the MCP server."
             },
             "auth_provider_key": {
               "type": "string",
@@ -1148,10 +1158,6 @@
                 "slack_identity_auth"
               ],
               "description": "A string specifying the authentication type. Possible values are dynamic_client_registration, no_auth, manual_auth, or slack_identity_auth."
-            },
-            "headers": {
-              "type": "object",
-              "description": "An object of HTTP headers to send with requests to the MCP server."
             }
           }
         }

--- a/schemas/manifest.schema.2.0.0.json
+++ b/schemas/manifest.schema.2.0.0.json
@@ -1243,13 +1243,23 @@
       "patternProperties": {
         ".*": {
           "type": "object",
-          "required": ["url"],
+          "required": ["url", "auth_type"],
           "properties": {
             "url": {
               "type": "string",
               "pattern": "^https:\\/\\/",
               "maxLength": 500,
               "description": "A string containing the URL of the MCP server. Maximum length is 500 characters."
+            },
+            "headers": {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^.+$": {
+                  "type": "string"
+                }
+              },
+              "description": "An object of HTTP headers to send with requests to the MCP server."
             },
             "auth_provider_key": {
               "type": "string",
@@ -1265,10 +1275,6 @@
                 "slack_identity_auth"
               ],
               "description": "A string specifying the authentication type. Possible values are dynamic_client_registration, no_auth, manual_auth, or slack_identity_auth."
-            },
-            "headers": {
-              "type": "object",
-              "description": "An object of HTTP headers to send with requests to the MCP server."
             }
           },
           "additionalProperties": false

--- a/schemas/manifest.schema.2.0.0.json
+++ b/schemas/manifest.schema.2.0.0.json
@@ -1193,10 +1193,11 @@
                     },
                     "use_pkce": {
                       "type": "boolean",
-                      "description": "Set to true if your server requires PKCE."
+                      "description": "Boolean flag indicating if this provider uses PKCE."
                     },
                     "token_url_config": {
                       "type": "object",
+                      "description": "An object with one boolean value, use_basic_auth_scheme.",
                       "properties": {
                         "use_basic_auth_scheme": {
                           "type": "boolean",

--- a/schemas/manifest.schema.2.0.0.json
+++ b/schemas/manifest.schema.2.0.0.json
@@ -42,6 +42,9 @@
     },
     "external_auth_providers": {
       "$ref": "#/definitions/app-manifests.v2.hermes.third_party_auth.providers"
+    },
+    "mcp_servers": {
+      "$ref": "#/definitions/app-manifests.v1.mcp_servers"
     }
   },
   "description": "Describes core app information and functionality.",
@@ -1187,6 +1190,20 @@
                         }
                       },
                       "additionalProperties": false
+                    },
+                    "use_pkce": {
+                      "type": "boolean",
+                      "description": "Set to true if your server requires PKCE."
+                    },
+                    "token_url_config": {
+                      "type": "object",
+                      "properties": {
+                        "use_basic_auth_scheme": {
+                          "type": "boolean",
+                          "description": "Set to true if your token endpoint expects client_secret_basic; false for client_secret_post."
+                        }
+                      },
+                      "additionalProperties": false
                     }
                   },
                   "additionalProperties": false
@@ -1217,6 +1234,38 @@
       },
       "description": "Declares the oauth configurations used by the app.",
       "additionalProperties": false
+    },
+    "app-manifests.v1.mcp_servers": {
+      "type": "object",
+      "description": "Declares the MCP servers used by the app.",
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "required": ["url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "pattern": "^https:\\/\\/",
+              "description": "The URL of the MCP server"
+            },
+            "auth_provider_key": {
+              "type": "string",
+              "description": "The key of the auth provider to use for authentication"
+            },
+            "auth_type": {
+              "type": "string",
+              "enum": [
+                "no_auth",
+                "slack_identity_auth",
+                "manual_auth",
+                "dynamic_client_registration"
+              ],
+              "description": "The authentication type for this MCP server"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
     }
   },
   "additionalProperties": false,

--- a/schemas/manifest.schema.2.0.0.json
+++ b/schemas/manifest.schema.2.0.0.json
@@ -1237,7 +1237,8 @@
     },
     "app-manifests.v1.mcp_servers": {
       "type": "object",
-      "description": "Declares the MCP servers used by the app.",
+      "description": "Declares the MCP servers used by the app. Maximum of 20 servers.",
+      "maxProperties": 20,
       "patternProperties": {
         ".*": {
           "type": "object",
@@ -1246,21 +1247,27 @@
             "url": {
               "type": "string",
               "pattern": "^https:\\/\\/",
-              "description": "The URL of the MCP server"
+              "maxLength": 500,
+              "description": "A string containing the URL of the MCP server. Maximum length is 500 characters."
             },
             "auth_provider_key": {
               "type": "string",
-              "description": "The key of the auth provider to use for authentication"
+              "maxLength": 255,
+              "description": "A string referencing the key of an external auth provider to use for authentication. Maximum length is 255 characters."
             },
             "auth_type": {
               "type": "string",
               "enum": [
+                "dynamic_client_registration",
                 "no_auth",
-                "slack_identity_auth",
                 "manual_auth",
-                "dynamic_client_registration"
+                "slack_identity_auth"
               ],
-              "description": "The authentication type for this MCP server"
+              "description": "A string specifying the authentication type. Possible values are dynamic_client_registration, no_auth, manual_auth, or slack_identity_auth."
+            },
+            "headers": {
+              "type": "object",
+              "description": "An object of HTTP headers to send with requests to the MCP server."
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
## Summary

This pull request adds the `mcp_servers` top-level property to both v1 and v2 manifest schemas, and adds `use_pkce` and `token_url_config` options to the external auth providers oauth2 configuration.

- Adds `mcp_servers` definition allowing apps to declare MCP server connections, capped at 20 servers per app
- Each server supports `url` (required, max 500 chars), `auth_type` (required), `auth_provider_key` (max 255 chars), and `headers` (a string-to-string map of HTTP headers)
- `auth_type` enum: `dynamic_client_registration`, `no_auth`, `manual_auth`, `slack_identity_auth`
- Adds `use_pkce` boolean to oauth2 provider options for PKCE support
- Adds `token_url_config.use_basic_auth_scheme` for configuring the token endpoint auth method

### Testing

- Validate a manifest with `mcp_servers` declared (including `headers`) passes schema validation
- Validate that a server missing `url` or `auth_type` is rejected
- Validate that an invalid `auth_type` enum value is rejected
- Validate that `use_pkce` and `token_url_config` are accepted within `external_auth_providers` oauth2 options
- Point an example manifest at the local versioned schema and confirm IDE validation/autocomplete works. Using the [slackbot-mcp-client sample](https://github.com/slack-samples/bolt-python-examples/tree/feat/mcp-client-examples/ai/slackbot-mcp-client), add a `$schema` key referencing the local file, e.g.:
  ```json
  {
    "$schema": "/path/to/manifest-schema/schemas/manifest.schema.1.0.0.json"
  }
  ```

### Category

* [x] `manifest.schema.json` edit
* [x] `/schema` and/or its core components

## Requirements

* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
