### PR TITLE
version 0.4.0

### DIFF
--- a/manifest.schema.json
+++ b/manifest.schema.json
@@ -21,7 +21,7 @@
           "required": ["_metadata"]
         },
         {
-          "$ref": "https://raw.githubusercontent.com/slackapi/manifest-schema/v0.3.0/schemas/manifest.schema.1.0.0.json"
+          "$ref": "https://raw.githubusercontent.com/slackapi/manifest-schema/v0.4.0/schemas/manifest.schema.1.0.0.json"
         }
       ]
     },
@@ -42,7 +42,7 @@
           "required": ["_metadata"]
         },
         {
-          "$ref": "https://raw.githubusercontent.com/slackapi/manifest-schema/v0.3.0/schemas/manifest.schema.2.0.0.json"
+          "$ref": "https://raw.githubusercontent.com/slackapi/manifest-schema/v0.4.0/schemas/manifest.schema.2.0.0.json"
         }
       ]
     },
@@ -60,7 +60,7 @@
           "required": ["_metadata"]
         },
         {
-          "$ref": "https://raw.githubusercontent.com/slackapi/manifest-schema/v0.3.0/schemas/manifest.schema.1.0.0.json"
+          "$ref": "https://raw.githubusercontent.com/slackapi/manifest-schema/v0.4.0/schemas/manifest.schema.1.0.0.json"
         }
       ]
     },
@@ -73,7 +73,7 @@
           }
         },
         {
-          "$ref": "https://raw.githubusercontent.com/slackapi/manifest-schema/v0.3.0/schemas/manifest.schema.1.0.0.json"
+          "$ref": "https://raw.githubusercontent.com/slackapi/manifest-schema/v0.4.0/schemas/manifest.schema.1.0.0.json"
         }
       ]
     }


### PR DESCRIPTION
## Summary

This pull request releases version `v0.4.0`, tagging the unreleased changes on `main`.

- Bumps the four `$ref` URLs in `manifest.schema.json` from `v0.3.0` to `v0.4.0`.
- Releases the following changes since `v0.3.0`:
  - feat: add `mcp_servers` property and `oauth_config` PKCE options (#71)
  - build(deps): bump pytest from 9.0.3 to 9.1.0 (#72)

### Testing

- Confirm the tag `v0.4.0` resolves: `curl -sI https://raw.githubusercontent.com/slackapi/manifest-schema/v0.4.0/schemas/manifest.schema.1.0.0.json` returns `200`.
- Run `./scripts/test.sh` and confirm the suite passes against the `v0.4.0` `$ref`s.

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `manifest.schema.json` edit
* [ ] `/schema` and/or its core components
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.