### PR TITLE
test: cover hosted + local schemas with agent_view test cases

### DIFF
--- a/schemas/manifest.schema.1.0.0.json
+++ b/schemas/manifest.schema.1.0.0.json
@@ -422,6 +422,57 @@
         }
       }
     },
+    "app-manifests.v1.features.agent_view": {
+      "type": "object",
+      "description": "Settings related to agent view for apps using agent features.",
+      "additionalProperties": false,
+      "properties": {
+        "agent_description": {
+          "type": "string",
+          "maxLength": 300,
+          "description": "A description specific to the agent, used to communicate to end users what agent functionality the app provides."
+        },
+        "suggested_prompts": {
+          "type": "array",
+          "maxItems": 4,
+          "description": "An array of pre-written prompts designed to guide users when interacting with the agent.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["title", "message"],
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "The prompt title."
+              },
+              "message": {
+                "type": "string",
+                "description": "The prompt content."
+              }
+            }
+          }
+        },
+        "actions": {
+          "type": "array",
+          "description": "Quick actions surfaced in the agent UI.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "description"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The action name."
+              },
+              "description": {
+                "type": "string",
+                "description": "A short description of what the action does."
+              }
+            }
+          }
+        }
+      }
+    },
     "app-manifests.v1.features.schema": {
       "type": "object",
       "description": "Key app features driving interactivity and functionality.",
@@ -450,6 +501,9 @@
         },
         "assistant_view": {
           "$ref": "#/definitions/app-manifests.v1.features.assistant_view"
+        },
+        "agent_view": {
+          "$ref": "#/definitions/app-manifests.v1.features.agent_view"
         }
       }
     },

--- a/schemas/manifest.schema.2.0.0.json
+++ b/schemas/manifest.schema.2.0.0.json
@@ -444,6 +444,57 @@
         }
       }
     },
+    "app-manifests.v1.features.agent_view": {
+      "type": "object",
+      "description": "Settings related to agent view for apps using agent features.",
+      "additionalProperties": false,
+      "properties": {
+        "agent_description": {
+          "type": "string",
+          "maxLength": 300,
+          "description": "A description specific to the agent, used to communicate to end users what agent functionality the app provides."
+        },
+        "suggested_prompts": {
+          "type": "array",
+          "maxItems": 4,
+          "description": "An array of pre-written prompts designed to guide users when interacting with the agent.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["title", "message"],
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "The prompt title."
+              },
+              "message": {
+                "type": "string",
+                "description": "The prompt content."
+              }
+            }
+          }
+        },
+        "actions": {
+          "type": "array",
+          "description": "Quick actions surfaced in the agent UI.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "description"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The action name."
+              },
+              "description": {
+                "type": "string",
+                "description": "A short description of what the action does."
+              }
+            }
+          }
+        }
+      }
+    },
     "app-manifests.v1.features.schema": {
       "type": "object",
       "properties": {
@@ -470,6 +521,9 @@
         },
         "assistant_view": {
           "$ref": "#/definitions/app-manifests.v1.features.assistant_view"
+        },
+        "agent_view": {
+          "$ref": "#/definitions/app-manifests.v1.features.agent_view"
         }
       },
       "description": "A group of settings corresponding to the Features section of the app config pages.",

--- a/tests/test_manifest_v1_schema.py
+++ b/tests/test_manifest_v1_schema.py
@@ -1,13 +1,34 @@
 import pytest
 from jsonschema import ValidationError, validate
 
-from .utils import get_json, get_schema
+from .utils import (
+    agent_view_fixture,
+    get_json,
+    get_schema,
+    get_schema_v1,
+    parametrize_agent_view_invalid,
+)
+
+
+# Each schema-content test runs against both:
+# - the hosted router schema (what IDEs and downstream consumers fetch)
+# - the local versioned schema (what the next release will ship)
+# Router-specific tests like test_no_metadata stay below, outside this matrix.
+SCHEMAS = [
+    pytest.param(get_schema, id="hosted"),
+    pytest.param(get_schema_v1, id="local"),
+]
+
+# New-feature tests only run against the local schema until the feature ships
+# in a release. After release, lift them into SCHEMAS by deleting this constant.
+SCHEMAS_LOCAL_ONLY = [pytest.param(get_schema_v1, id="local")]
 
 
 class TestManifestV1Schema:
-    def test_success(self):
+    @pytest.mark.parametrize("load_schema", SCHEMAS)
+    def test_success(self, load_schema):
         # GIVEN
-        schema = get_schema()
+        schema = load_schema()
         manifest = get_json("tests/manifests/v1/manifest.valid.json")
         # WHEN
         try:
@@ -17,7 +38,7 @@ class TestManifestV1Schema:
             assert False, f"validation failed: {e}"
 
     def test_no_metadata(self):
-        # GIVEN
+        # GIVEN — router falls back to v1 when _metadata is absent
         schema = get_schema()
         manifest = get_json("tests/manifests/v1/manifest.valid.json")
         del manifest["_metadata"]
@@ -28,10 +49,39 @@ class TestManifestV1Schema:
             # THEN
             assert False, f"validation failed: {e}"
 
-    def test_invalid(self):
+    @pytest.mark.parametrize("load_schema", SCHEMAS)
+    def test_invalid(self, load_schema):
         # GIVEN
-        schema = get_schema()
+        schema = load_schema()
         manifest = get_json("tests/manifests/v1/manifest.invalid.json")
+        # WHEN
+        with pytest.raises(ValidationError):
+            validate(manifest, schema)
+        # THEN validation exception is raised
+
+
+class TestManifestV1AgentView:
+    @pytest.mark.parametrize("load_schema", SCHEMAS_LOCAL_ONLY)
+    def test_valid(self, load_schema):
+        # GIVEN
+        schema = load_schema()
+        manifest = get_json("tests/manifests/v1/manifest.valid.json")
+        manifest["features"]["agent_view"] = agent_view_fixture()
+        # WHEN
+        try:
+            validate(manifest, schema)
+        except ValidationError as e:
+            # THEN
+            assert False, f"validation failed: {e}"
+
+    @pytest.mark.parametrize("load_schema", SCHEMAS_LOCAL_ONLY)
+    @parametrize_agent_view_invalid()
+    def test_invalid(self, load_schema, mutation):
+        # GIVEN
+        schema = load_schema()
+        manifest = get_json("tests/manifests/v1/manifest.valid.json")
+        manifest["features"]["agent_view"] = agent_view_fixture()
+        mutation(manifest["features"]["agent_view"])
         # WHEN
         with pytest.raises(ValidationError):
             validate(manifest, schema)

--- a/tests/test_manifest_v1_schema.py
+++ b/tests/test_manifest_v1_schema.py
@@ -1,7 +1,7 @@
 import pytest
 from jsonschema import ValidationError, validate
 
-from .utils import get_json, get_schema
+from .utils import get_json, get_schema, get_schema_v1
 
 
 class TestManifestV1Schema:
@@ -32,6 +32,88 @@ class TestManifestV1Schema:
         # GIVEN
         schema = get_schema()
         manifest = get_json("tests/manifests/v1/manifest.invalid.json")
+        # WHEN
+        with pytest.raises(ValidationError):
+            validate(manifest, schema)
+        # THEN validation exception is raised
+
+
+def _agent_view_fixture():
+    return {
+        "agent_description": "A sample agent that demonstrates agent_view manifest settings.",
+        "suggested_prompts": [
+            {
+                "title": "Summarize this thread",
+                "message": "Please summarize the conversation in this thread.",
+            },
+            {
+                "title": "Draft a reply",
+                "message": "Draft a reply to the most recent message.",
+            },
+        ],
+        "actions": [
+            {"name": "open_settings", "description": "Open the agent settings panel."},
+        ],
+    }
+
+
+class TestManifestV1AgentView:
+    """Validates the local v1 schema (not the GitHub-pinned router) so changes
+    to schemas/manifest.schema.1.0.0.json are exercised before release."""
+
+    def _manifest_with_agent_view(self):
+        manifest = get_json("tests/manifests/v1/manifest.valid.json")
+        manifest["features"]["agent_view"] = _agent_view_fixture()
+        return manifest
+
+    def test_agent_view_valid(self):
+        # GIVEN — manifest with a fully populated agent_view block
+        schema = get_schema_v1()
+        manifest = self._manifest_with_agent_view()
+        # WHEN
+        try:
+            validate(manifest, schema)
+        except ValidationError as e:
+            # THEN
+            assert False, f"validation failed: {e}"
+
+    def test_agent_view_too_many_prompts(self):
+        # GIVEN — suggested_prompts is capped at 4
+        schema = get_schema_v1()
+        manifest = self._manifest_with_agent_view()
+        manifest["features"]["agent_view"]["suggested_prompts"] = [
+            {"title": f"prompt {i}", "message": f"message {i}"} for i in range(5)
+        ]
+        # WHEN
+        with pytest.raises(ValidationError):
+            validate(manifest, schema)
+        # THEN validation exception is raised
+
+    def test_agent_view_action_missing_description(self):
+        # GIVEN — actions[].description is required
+        schema = get_schema_v1()
+        manifest = self._manifest_with_agent_view()
+        manifest["features"]["agent_view"]["actions"] = [{"name": "open_settings"}]
+        # WHEN
+        with pytest.raises(ValidationError):
+            validate(manifest, schema)
+        # THEN validation exception is raised
+
+    def test_agent_view_description_too_long(self):
+        # GIVEN — agent_description is capped at 300 chars
+        schema = get_schema_v1()
+        manifest = self._manifest_with_agent_view()
+        manifest["features"]["agent_view"]["agent_description"] = "x" * 301
+        # WHEN
+        with pytest.raises(ValidationError):
+            validate(manifest, schema)
+        # THEN validation exception is raised
+
+    def test_agent_view_additional_property_rejected(self):
+        # GIVEN — additionalProperties is false on agent_view
+        schema = get_schema_v1()
+        manifest = self._manifest_with_agent_view()
+        manifest["features"]["agent_view"]["unexpected_field"] = True
         # WHEN
         with pytest.raises(ValidationError):
             validate(manifest, schema)

--- a/tests/test_manifest_v1_schema.py
+++ b/tests/test_manifest_v1_schema.py
@@ -1,7 +1,7 @@
 import pytest
 from jsonschema import ValidationError, validate
 
-from .utils import get_json, get_schema, get_schema_v1
+from .utils import get_json, get_schema
 
 
 class TestManifestV1Schema:
@@ -32,88 +32,6 @@ class TestManifestV1Schema:
         # GIVEN
         schema = get_schema()
         manifest = get_json("tests/manifests/v1/manifest.invalid.json")
-        # WHEN
-        with pytest.raises(ValidationError):
-            validate(manifest, schema)
-        # THEN validation exception is raised
-
-
-def _agent_view_fixture():
-    return {
-        "agent_description": "A sample agent that demonstrates agent_view manifest settings.",
-        "suggested_prompts": [
-            {
-                "title": "Summarize this thread",
-                "message": "Please summarize the conversation in this thread.",
-            },
-            {
-                "title": "Draft a reply",
-                "message": "Draft a reply to the most recent message.",
-            },
-        ],
-        "actions": [
-            {"name": "open_settings", "description": "Open the agent settings panel."},
-        ],
-    }
-
-
-class TestManifestV1AgentView:
-    """Validates the local v1 schema (not the GitHub-pinned router) so changes
-    to schemas/manifest.schema.1.0.0.json are exercised before release."""
-
-    def _manifest_with_agent_view(self):
-        manifest = get_json("tests/manifests/v1/manifest.valid.json")
-        manifest["features"]["agent_view"] = _agent_view_fixture()
-        return manifest
-
-    def test_agent_view_valid(self):
-        # GIVEN — manifest with a fully populated agent_view block
-        schema = get_schema_v1()
-        manifest = self._manifest_with_agent_view()
-        # WHEN
-        try:
-            validate(manifest, schema)
-        except ValidationError as e:
-            # THEN
-            assert False, f"validation failed: {e}"
-
-    def test_agent_view_too_many_prompts(self):
-        # GIVEN — suggested_prompts is capped at 4
-        schema = get_schema_v1()
-        manifest = self._manifest_with_agent_view()
-        manifest["features"]["agent_view"]["suggested_prompts"] = [
-            {"title": f"prompt {i}", "message": f"message {i}"} for i in range(5)
-        ]
-        # WHEN
-        with pytest.raises(ValidationError):
-            validate(manifest, schema)
-        # THEN validation exception is raised
-
-    def test_agent_view_action_missing_description(self):
-        # GIVEN — actions[].description is required
-        schema = get_schema_v1()
-        manifest = self._manifest_with_agent_view()
-        manifest["features"]["agent_view"]["actions"] = [{"name": "open_settings"}]
-        # WHEN
-        with pytest.raises(ValidationError):
-            validate(manifest, schema)
-        # THEN validation exception is raised
-
-    def test_agent_view_description_too_long(self):
-        # GIVEN — agent_description is capped at 300 chars
-        schema = get_schema_v1()
-        manifest = self._manifest_with_agent_view()
-        manifest["features"]["agent_view"]["agent_description"] = "x" * 301
-        # WHEN
-        with pytest.raises(ValidationError):
-            validate(manifest, schema)
-        # THEN validation exception is raised
-
-    def test_agent_view_additional_property_rejected(self):
-        # GIVEN — additionalProperties is false on agent_view
-        schema = get_schema_v1()
-        manifest = self._manifest_with_agent_view()
-        manifest["features"]["agent_view"]["unexpected_field"] = True
         # WHEN
         with pytest.raises(ValidationError):
             validate(manifest, schema)

--- a/tests/test_manifest_v2_schema.py
+++ b/tests/test_manifest_v2_schema.py
@@ -1,7 +1,7 @@
 import pytest
 from jsonschema import ValidationError, validate
 
-from .utils import get_json, get_schema
+from .utils import get_json, get_schema, get_schema_v2
 
 
 class TestManifestV2Schema:
@@ -30,6 +30,84 @@ class TestManifestV2Schema:
         # GIVEN
         schema = get_schema()
         manifest = get_json("tests/manifests/v2/manifest.invalid.json")
+        # WHEN
+        with pytest.raises(ValidationError):
+            validate(manifest, schema)
+        # THEN validation exception is raised
+
+
+def _agent_view_fixture():
+    return {
+        "agent_description": "A sample agent that demonstrates agent_view manifest settings.",
+        "suggested_prompts": [
+            {
+                "title": "Summarize this thread",
+                "message": "Please summarize the conversation in this thread.",
+            },
+        ],
+        "actions": [
+            {"name": "open_settings", "description": "Open the agent settings panel."},
+        ],
+    }
+
+
+class TestManifestV2AgentView:
+    """Validates the local v2 schema (not the GitHub-pinned router) so changes
+    to schemas/manifest.schema.2.0.0.json are exercised before release."""
+
+    def _manifest_with_agent_view(self):
+        manifest = get_json("tests/manifests/v2/manifest.valid.json")
+        manifest["features"]["agent_view"] = _agent_view_fixture()
+        return manifest
+
+    def test_agent_view_valid(self):
+        # GIVEN — manifest with a fully populated agent_view block
+        schema = get_schema_v2()
+        manifest = self._manifest_with_agent_view()
+        # WHEN
+        try:
+            validate(manifest, schema)
+        except ValidationError as e:
+            # THEN
+            assert False, f"validation failed: {e}"
+
+    def test_agent_view_too_many_prompts(self):
+        # GIVEN — suggested_prompts is capped at 4
+        schema = get_schema_v2()
+        manifest = self._manifest_with_agent_view()
+        manifest["features"]["agent_view"]["suggested_prompts"] = [
+            {"title": f"prompt {i}", "message": f"message {i}"} for i in range(5)
+        ]
+        # WHEN
+        with pytest.raises(ValidationError):
+            validate(manifest, schema)
+        # THEN validation exception is raised
+
+    def test_agent_view_action_missing_description(self):
+        # GIVEN — actions[].description is required
+        schema = get_schema_v2()
+        manifest = self._manifest_with_agent_view()
+        manifest["features"]["agent_view"]["actions"] = [{"name": "open_settings"}]
+        # WHEN
+        with pytest.raises(ValidationError):
+            validate(manifest, schema)
+        # THEN validation exception is raised
+
+    def test_agent_view_description_too_long(self):
+        # GIVEN — agent_description is capped at 300 chars
+        schema = get_schema_v2()
+        manifest = self._manifest_with_agent_view()
+        manifest["features"]["agent_view"]["agent_description"] = "x" * 301
+        # WHEN
+        with pytest.raises(ValidationError):
+            validate(manifest, schema)
+        # THEN validation exception is raised
+
+    def test_agent_view_additional_property_rejected(self):
+        # GIVEN — additionalProperties is false on agent_view
+        schema = get_schema_v2()
+        manifest = self._manifest_with_agent_view()
+        manifest["features"]["agent_view"]["unexpected_field"] = True
         # WHEN
         with pytest.raises(ValidationError):
             validate(manifest, schema)

--- a/tests/test_manifest_v2_schema.py
+++ b/tests/test_manifest_v2_schema.py
@@ -1,7 +1,7 @@
 import pytest
 from jsonschema import ValidationError, validate
 
-from .utils import get_json, get_schema, get_schema_v2
+from .utils import get_json, get_schema
 
 
 class TestManifestV2Schema:
@@ -30,84 +30,6 @@ class TestManifestV2Schema:
         # GIVEN
         schema = get_schema()
         manifest = get_json("tests/manifests/v2/manifest.invalid.json")
-        # WHEN
-        with pytest.raises(ValidationError):
-            validate(manifest, schema)
-        # THEN validation exception is raised
-
-
-def _agent_view_fixture():
-    return {
-        "agent_description": "A sample agent that demonstrates agent_view manifest settings.",
-        "suggested_prompts": [
-            {
-                "title": "Summarize this thread",
-                "message": "Please summarize the conversation in this thread.",
-            },
-        ],
-        "actions": [
-            {"name": "open_settings", "description": "Open the agent settings panel."},
-        ],
-    }
-
-
-class TestManifestV2AgentView:
-    """Validates the local v2 schema (not the GitHub-pinned router) so changes
-    to schemas/manifest.schema.2.0.0.json are exercised before release."""
-
-    def _manifest_with_agent_view(self):
-        manifest = get_json("tests/manifests/v2/manifest.valid.json")
-        manifest["features"]["agent_view"] = _agent_view_fixture()
-        return manifest
-
-    def test_agent_view_valid(self):
-        # GIVEN — manifest with a fully populated agent_view block
-        schema = get_schema_v2()
-        manifest = self._manifest_with_agent_view()
-        # WHEN
-        try:
-            validate(manifest, schema)
-        except ValidationError as e:
-            # THEN
-            assert False, f"validation failed: {e}"
-
-    def test_agent_view_too_many_prompts(self):
-        # GIVEN — suggested_prompts is capped at 4
-        schema = get_schema_v2()
-        manifest = self._manifest_with_agent_view()
-        manifest["features"]["agent_view"]["suggested_prompts"] = [
-            {"title": f"prompt {i}", "message": f"message {i}"} for i in range(5)
-        ]
-        # WHEN
-        with pytest.raises(ValidationError):
-            validate(manifest, schema)
-        # THEN validation exception is raised
-
-    def test_agent_view_action_missing_description(self):
-        # GIVEN — actions[].description is required
-        schema = get_schema_v2()
-        manifest = self._manifest_with_agent_view()
-        manifest["features"]["agent_view"]["actions"] = [{"name": "open_settings"}]
-        # WHEN
-        with pytest.raises(ValidationError):
-            validate(manifest, schema)
-        # THEN validation exception is raised
-
-    def test_agent_view_description_too_long(self):
-        # GIVEN — agent_description is capped at 300 chars
-        schema = get_schema_v2()
-        manifest = self._manifest_with_agent_view()
-        manifest["features"]["agent_view"]["agent_description"] = "x" * 301
-        # WHEN
-        with pytest.raises(ValidationError):
-            validate(manifest, schema)
-        # THEN validation exception is raised
-
-    def test_agent_view_additional_property_rejected(self):
-        # GIVEN — additionalProperties is false on agent_view
-        schema = get_schema_v2()
-        manifest = self._manifest_with_agent_view()
-        manifest["features"]["agent_view"]["unexpected_field"] = True
         # WHEN
         with pytest.raises(ValidationError):
             validate(manifest, schema)

--- a/tests/test_manifest_v2_schema.py
+++ b/tests/test_manifest_v2_schema.py
@@ -1,13 +1,34 @@
 import pytest
 from jsonschema import ValidationError, validate
 
-from .utils import get_json, get_schema
+from .utils import (
+    agent_view_fixture,
+    get_json,
+    get_schema,
+    get_schema_v2,
+    parametrize_agent_view_invalid,
+)
+
+
+# Each schema-content test runs against both:
+# - the hosted router schema (what IDEs and downstream consumers fetch)
+# - the local versioned schema (what the next release will ship)
+# Router-specific tests like test_no_metadata stay below, outside this matrix.
+SCHEMAS = [
+    pytest.param(get_schema, id="hosted"),
+    pytest.param(get_schema_v2, id="local"),
+]
+
+# New-feature tests only run against the local schema until the feature ships
+# in a release. After release, lift them into SCHEMAS by deleting this constant.
+SCHEMAS_LOCAL_ONLY = [pytest.param(get_schema_v2, id="local")]
 
 
 class TestManifestV2Schema:
-    def test_success(self):
+    @pytest.mark.parametrize("load_schema", SCHEMAS)
+    def test_success(self, load_schema):
         # GIVEN
-        schema = get_schema()
+        schema = load_schema()
         manifest = get_json("tests/manifests/v2/manifest.valid.json")
         # WHEN
         try:
@@ -17,7 +38,7 @@ class TestManifestV2Schema:
             assert False, f"validation failed: {e}"
 
     def test_no_metadata(self):
-        # GIVEN
+        # GIVEN — v2 requires _metadata; router rejects when it's absent
         schema = get_schema()
         manifest = get_json("tests/manifests/v2/manifest.valid.json")
         del manifest["_metadata"]
@@ -26,10 +47,39 @@ class TestManifestV2Schema:
             validate(manifest, schema)
         # THEN validation exception is raised
 
-    def test_invalid(self):
+    @pytest.mark.parametrize("load_schema", SCHEMAS)
+    def test_invalid(self, load_schema):
         # GIVEN
-        schema = get_schema()
+        schema = load_schema()
         manifest = get_json("tests/manifests/v2/manifest.invalid.json")
+        # WHEN
+        with pytest.raises(ValidationError):
+            validate(manifest, schema)
+        # THEN validation exception is raised
+
+
+class TestManifestV2AgentView:
+    @pytest.mark.parametrize("load_schema", SCHEMAS_LOCAL_ONLY)
+    def test_valid(self, load_schema):
+        # GIVEN
+        schema = load_schema()
+        manifest = get_json("tests/manifests/v2/manifest.valid.json")
+        manifest["features"]["agent_view"] = agent_view_fixture()
+        # WHEN
+        try:
+            validate(manifest, schema)
+        except ValidationError as e:
+            # THEN
+            assert False, f"validation failed: {e}"
+
+    @pytest.mark.parametrize("load_schema", SCHEMAS_LOCAL_ONLY)
+    @parametrize_agent_view_invalid()
+    def test_invalid(self, load_schema, mutation):
+        # GIVEN
+        schema = load_schema()
+        manifest = get_json("tests/manifests/v2/manifest.valid.json")
+        manifest["features"]["agent_view"] = agent_view_fixture()
+        mutation(manifest["features"]["agent_view"])
         # WHEN
         with pytest.raises(ValidationError):
             validate(manifest, schema)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,8 +2,6 @@ import json
 from typing import Dict
 
 MANIFEST_SCHEMA_PATH = "manifest.schema.json"
-MANIFEST_SCHEMA_V1_PATH = "schemas/manifest.schema.1.0.0.json"
-MANIFEST_SCHEMA_V2_PATH = "schemas/manifest.schema.2.0.0.json"
 
 
 def get_json(path: str) -> Dict:
@@ -13,11 +11,3 @@ def get_json(path: str) -> Dict:
 
 def get_schema() -> Dict:
     return get_json(MANIFEST_SCHEMA_PATH)
-
-
-def get_schema_v1() -> Dict:
-    return get_json(MANIFEST_SCHEMA_V1_PATH)
-
-
-def get_schema_v2() -> Dict:
-    return get_json(MANIFEST_SCHEMA_V2_PATH)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,8 @@ import json
 from typing import Dict
 
 MANIFEST_SCHEMA_PATH = "manifest.schema.json"
+MANIFEST_SCHEMA_V1_PATH = "schemas/manifest.schema.1.0.0.json"
+MANIFEST_SCHEMA_V2_PATH = "schemas/manifest.schema.2.0.0.json"
 
 
 def get_json(path: str) -> Dict:
@@ -11,3 +13,11 @@ def get_json(path: str) -> Dict:
 
 def get_schema() -> Dict:
     return get_json(MANIFEST_SCHEMA_PATH)
+
+
+def get_schema_v1() -> Dict:
+    return get_json(MANIFEST_SCHEMA_V1_PATH)
+
+
+def get_schema_v2() -> Dict:
+    return get_json(MANIFEST_SCHEMA_V2_PATH)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,11 @@
 import json
-from typing import Dict
+from typing import Callable, Dict, List, Tuple
+
+import pytest
 
 MANIFEST_SCHEMA_PATH = "manifest.schema.json"
+MANIFEST_SCHEMA_V1_PATH = "schemas/manifest.schema.1.0.0.json"
+MANIFEST_SCHEMA_V2_PATH = "schemas/manifest.schema.2.0.0.json"
 
 
 def get_json(path: str) -> Dict:
@@ -10,4 +14,63 @@ def get_json(path: str) -> Dict:
 
 
 def get_schema() -> Dict:
+    """Top-level router schema — what IDEs and downstream consumers fetch."""
     return get_json(MANIFEST_SCHEMA_PATH)
+
+
+def get_schema_v1() -> Dict:
+    """Local v1 schema — what the next release artifact will ship."""
+    return get_json(MANIFEST_SCHEMA_V1_PATH)
+
+
+def get_schema_v2() -> Dict:
+    """Local v2 schema — what the next release artifact will ship."""
+    return get_json(MANIFEST_SCHEMA_V2_PATH)
+
+
+# Shared agent_view block used to exercise the schema definition. Lives here so
+# v1 and v2 test files stay in sync — agent_view is defined identically in both.
+def agent_view_fixture() -> Dict:
+    return {
+        "agent_description": "A sample agent that demonstrates agent_view manifest settings.",
+        "suggested_prompts": [
+            {"title": "Summarize this thread", "message": "Please summarize the conversation."},
+        ],
+        "actions": [
+            {"name": "open_settings", "description": "Open the agent settings panel."},
+        ],
+    }
+
+
+# (id, mutation) pairs for invalid agent_view shapes — applied to a fresh fixture
+# inside each test so cases stay independent. Shared between v1 and v2 because
+# the constraints (maxItems, maxLength, additionalProperties: false, required
+# fields) are identical across versions.
+AGENT_VIEW_INVALID_CASES: List[Tuple[str, Callable[[Dict], None]]] = [
+    (
+        "too_many_suggested_prompts",
+        lambda av: av.update(
+            {"suggested_prompts": [{"title": f"p{i}", "message": f"m{i}"} for i in range(5)]}
+        ),
+    ),
+    (
+        "action_missing_description",
+        lambda av: av.update({"actions": [{"name": "open_settings"}]}),
+    ),
+    (
+        "agent_description_too_long",
+        lambda av: av.update({"agent_description": "x" * 301}),
+    ),
+    (
+        "additional_property_rejected",
+        lambda av: av.update({"unexpected_field": True}),
+    ),
+]
+
+
+def parametrize_agent_view_invalid():
+    """Decorator: parametrize a test method with the shared invalid mutations."""
+    return pytest.mark.parametrize(
+        "mutation",
+        [pytest.param(fn, id=name) for name, fn in AGENT_VIEW_INVALID_CASES],
+    )


### PR DESCRIPTION
## Summary

Stacks on top of #74 — base branch is `mwbrooks-manifest-agent-view`.

- Parametrizes the existing v1/v2 `test_success` and `test_invalid` cases across **both** schema surfaces:
  - `hosted` — the GitHub-pinned router schema that IDEs and downstream consumers actually fetch
  - `local` — the versioned schema files in `schemas/` that the next release will ship
- Hoists a shared `agent_view` valid fixture and a shared invalid-mutation table into `tests/utils.py`. v1 and v2 reuse the same data because `agent_view` is defined identically across versions.
- Adds `TestManifest{V1,V2}AgentView` covering valid manifest + 4 invalid mutations (maxItems on `suggested_prompts`, missing `description` on `actions[]`, `agent_description` over 300 chars, `additionalProperties` rejected).
- agent_view cases are pinned to local-only via `SCHEMAS_LOCAL_ONLY` until the property is published in a release. Once published, promote them by deleting the local-only constant.

## Why

Existing tests validate against the GitHub-pinned router (currently `v0.4.0`), so edits to the local versioned schema files were never exercised before release. This made past PRs like `mcp_servers` and `is_mcp_enabled` ship without local test coverage. The hosted+local matrix means new properties get validated locally on every PR while still confirming the released router stays compatible with the canonical fixtures.

## Test plan

- [x] `pytest -v` — 20/20 pass (10 base × 2 schemas + 10 agent_view local-only)
- [x] `./scripts/lint.sh` — clean
- [x] CI green

## Follow-ups

- Once `agent_view` ships in a release, delete `SCHEMAS_LOCAL_ONLY` so the agent_view tests run against the hosted schema too.