### PR TITLE
feat: add code_channels feature to the manifest schema

### DIFF
--- a/schemas/manifest.schema.1.0.0.json
+++ b/schemas/manifest.schema.1.0.0.json
@@ -473,6 +473,24 @@
         }
       }
     },
+    "app-manifests.v1.features.code_channels": {
+      "type": "object",
+      "description": "Settings for apps that create code channels: dedicated channels where an agent collaborates with a user on a task.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "A boolean that specifies whether or not code channels are enabled for the app."
+        },
+        "slash_command_url": {
+          "type": "string",
+          "format": "uri",
+          "maxLength": 3000,
+          "pattern": "^https?://",
+          "description": "The URL where Slack delivers invocations of the agent's runtime-registered code channel slash commands. Must be an http:// or https:// URL, at most 3000 characters. Not required for Socket Mode or hosted apps."
+        }
+      }
+    },
     "app-manifests.v1.features.schema": {
       "type": "object",
       "description": "Key app features driving interactivity and functionality.",
@@ -504,6 +522,9 @@
         },
         "agent_view": {
           "$ref": "#/definitions/app-manifests.v1.features.agent_view"
+        },
+        "code_channels": {
+          "$ref": "#/definitions/app-manifests.v1.features.code_channels"
         }
       }
     },

--- a/schemas/manifest.schema.2.0.0.json
+++ b/schemas/manifest.schema.2.0.0.json
@@ -495,6 +495,24 @@
         }
       }
     },
+    "app-manifests.v1.features.code_channels": {
+      "type": "object",
+      "description": "Settings for apps that create code channels: dedicated channels where an agent collaborates with a user on a task.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "A boolean that specifies whether or not code channels are enabled for the app."
+        },
+        "slash_command_url": {
+          "type": "string",
+          "format": "uri",
+          "maxLength": 3000,
+          "pattern": "^https?://",
+          "description": "The URL where Slack delivers invocations of the agent's runtime-registered code channel slash commands. Must be an http:// or https:// URL, at most 3000 characters. Not required for Socket Mode or hosted apps."
+        }
+      }
+    },
     "app-manifests.v1.features.schema": {
       "type": "object",
       "properties": {
@@ -524,6 +542,9 @@
         },
         "agent_view": {
           "$ref": "#/definitions/app-manifests.v1.features.agent_view"
+        },
+        "code_channels": {
+          "$ref": "#/definitions/app-manifests.v1.features.code_channels"
         }
       },
       "description": "A group of settings corresponding to the Features section of the app config pages.",


### PR DESCRIPTION
Adds a `code_channels` feature block to the app manifest schema (v1 and v2), so manifests that declare it validate and get editor autocomplete.

- `features.code_channels.enabled` (boolean)
- `features.code_channels.slash_command_url` (optional string; `uri`, `https?://`, max 3000)

Mirrors the existing feature-block pattern (e.g. `agent_view`). Adds a focused test validating the new block against the versioned schemas.