### PR TITLE
test: cover in progress code_channels in the v1/v2 manifest fixtures

### DIFF
--- a/tests/manifests/v1/manifest.valid.json
+++ b/tests/manifests/v1/manifest.valid.json
@@ -17,6 +17,10 @@
       "display_name": "Bolt Template App",
       "always_online": false
     },
+    "code_channels": {
+      "enabled": true,
+      "slash_command_url": "https://example.com/slack/code-channel-commands"
+    },
     "shortcuts": [
       {
         "name": "Run sample shortcut",

--- a/tests/manifests/v2/manifest.valid.json
+++ b/tests/manifests/v2/manifest.valid.json
@@ -15,6 +15,10 @@
     "bot_user": {
       "display_name": "test",
       "always_online": false
+    },
+    "code_channels": {
+      "enabled": true,
+      "slash_command_url": "https://example.com/slack/code-channel-commands"
     }
   },
   "oauth_config": {

--- a/tests/test_manifest_v1_schema.py
+++ b/tests/test_manifest_v1_schema.py
@@ -1,13 +1,13 @@
 import pytest
 from jsonschema import ValidationError, validate
 
-from .utils import get_json, get_schema
+from .utils import get_json, get_local_schema, get_schema
 
 
 class TestManifestV1Schema:
     def test_success(self):
         # GIVEN
-        schema = get_schema()
+        schema = get_local_schema(1)
         manifest = get_json("tests/manifests/v1/manifest.valid.json")
         # WHEN
         try:
@@ -18,7 +18,7 @@ class TestManifestV1Schema:
 
     def test_no_metadata(self):
         # GIVEN
-        schema = get_schema()
+        schema = get_local_schema(1)
         manifest = get_json("tests/manifests/v1/manifest.valid.json")
         del manifest["_metadata"]
         # WHEN

--- a/tests/test_manifest_v2_schema.py
+++ b/tests/test_manifest_v2_schema.py
@@ -1,13 +1,13 @@
 import pytest
 from jsonschema import ValidationError, validate
 
-from .utils import get_json, get_schema
+from .utils import get_json, get_local_schema, get_schema
 
 
 class TestManifestV2Schema:
     def test_success(self):
         # GIVEN
-        schema = get_schema()
+        schema = get_local_schema(2)
         manifest = get_json("tests/manifests/v2/manifest.valid.json")
         # WHEN
         try:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,11 @@ from typing import Dict
 
 MANIFEST_SCHEMA_PATH = "manifest.schema.json"
 
+LOCAL_SCHEMA_PATHS = {
+    1: "schemas/manifest.schema.1.0.0.json",
+    2: "schemas/manifest.schema.2.0.0.json",
+}
+
 
 def get_json(path: str) -> Dict:
     with open(path, "r", encoding="utf-8") as f:
@@ -11,3 +16,7 @@ def get_json(path: str) -> Dict:
 
 def get_schema() -> Dict:
     return get_json(MANIFEST_SCHEMA_PATH)
+
+
+def get_local_schema(major_version: int) -> Dict:
+    return get_json(LOCAL_SCHEMA_PATHS[major_version])


### PR DESCRIPTION
Adds the `code_channels` feature to the existing v1 and v2 valid manifest fixtures, so the existing `test_success` cases exercise it. Points the versioned fixtures at their versioned local schemas (`schemas/manifest.schema.{1,2}.0.0.json`) rather than the network-pinned dispatcher, since the dispatcher lags un-released schema changes.

Stacked on #86 (the schema change).